### PR TITLE
Added Python shebang

### DIFF
--- a/computematrix.py
+++ b/computematrix.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 import dendropy
 import numpy as np
 import sys, getopt


### PR DESCRIPTION
In Unix, you can add what's called a "shebang" to the first line of a script, and then if you mark the script as executable using chmod a+x MYSCRIPT then users can execute your script just like a normal program. For example, if you now go and make this file executable (which you should, and then push the change), you will be able to run it like ./computematrix.py

Also, when developing tools, it's good to try to be as portable as possible. In your code, one thing that stands out is that you write print statements using "print MYSTATEMENT" instead of "print(MYSTATEMENT)" (i.e., you don't put parentheses). This works fine in Python 2, but in Python 3, this will throw a syntax error. If your code was doing other stuff that absolutely needed Python 2, then it would be okay to do this because people are forced to use Python 2 to use your code anyways, but given that your code isn't doing anything super fancy that requires Python 2 instead of Python 3, it's good practice to use parentheses on print statements to make your code compatible with both