### PR TITLE
Put parentheses around print statements

### DIFF
--- a/format.py
+++ b/format.py
@@ -9,18 +9,18 @@ if __name__ == "__main__":
     try:
         opts, args = getopt.getopt(argv,"hi:o:",["ifile=","ofile="])
     except getopt.GetoptError:
-        print 'test.py -i <inputfile> -o <outputfile>'
+        print('test.py -i <inputfile> -o <outputfile>')
         sys.exit(2)
     for opt, arg in opts:
         if opt == '-h':
-            print 'test.py -i <inputfile> -o <outputfile>'
+            print('test.py -i <inputfile> -o <outputfile>')
             sys.exit()
         elif opt in ("-i", "--ifile"):
             inputfile = arg
         elif opt in ("-o", "--ofile"):
             outputfile = arg
-            print 'Input file is "', inputfile
-            print 'Output file is "', outputfile
+            print('Input file is "', inputfile)
+            print('Output file is "', outputfile)
 
     input = open(inputfile,"r")
     output = open(outputfile,"w")


### PR DESCRIPTION
I mentioned this in another comment, but in general, it's good to write Python code that is compatible with both Python 2 and Python 3 so that your user can run it no matter what they have installed on their system. Thus, I added parentheses around all your print statements because Python 3 requires them, yet Python 2 will still work fine with them